### PR TITLE
Updated to our Dependency Tester

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,26 @@
 name: CI
 
-on: [push]
-
-env:
-  CI: true
+on: 
+  - push
+  - pull_request
 
 jobs:
-  Test:
+  test:
+    name: Test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        channel: [stable, beta]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
-    - uses: UziTech/action-setup-atom@v2
-      with:
-        version: ${{ matrix.channel }}
-    - name: Install dependencies
-      run: apm install
-    - name: Run tests
-      run: atom --test spec
+      - name: Checkout the Latest Package Code
+        uses: actions/checkout@v3
+      - name: Setup Pulsar Editor
+        uses: pulsar-edit/action-pulsar-dependency@v2.1
+        with:
+          package-to-test: "markdown-preview"
+      - name: Run the headless Pulsar Tests 
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: yarn start --test spec
+          working-directory: ./pulsar


### PR DESCRIPTION
This PR starts using our own [`action-pulsar-dependency`](https://github.com/marketplace/actions/action-pulsar-dependency-tester) tester for CI. As well as starts using them on Pull Requests.